### PR TITLE
Add externally managed services to RAM share

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -274,10 +274,25 @@ resource "aws_ram_resource_association" "ram_service_network_association" {
   resource_share_arn = local.resource_share_arn
 }
 
+locals {
+  ram_services_association_resources = {
+    for svc in local.share_services :
+      svc => lookup(
+        aws_vpclattice_service.lattice_service,
+        svc,
+        lookup(
+          data.aws_vpclattice_service.lattice_service,
+          svc,
+          null
+        )
+      )
+  }
+}
+
 # AWS RAM resource association - VPC Lattice services
 resource "aws_ram_resource_association" "ram_services_association" {
   count = local.config_ram_share ? length(local.share_services) : 0
 
-  resource_arn       = aws_vpclattice_service.lattice_service[local.share_services[count.index]].arn
+  resource_arn       = local.ram_services_association_resources[local.share_services[count.index]].arn
   resource_share_arn = local.resource_share_arn
 }


### PR DESCRIPTION
**Problem**:
Cannot use this module to share VPC Lattice service that is managed outside of it, for example created with [AWS Gateway API Controller](https://www.gateway-api-controller.eks.aws.dev/latest/).

**Solution**:
When looking up ARN of VPC Lattice service to associate with a RAM share, use data source if resource is not available.

**Notes**:
[Support for DNS record management for VPC Lattice services created outside of this module is already there](https://github.com/aws-ia/terraform-aws-amazon-vpc-lattice-module/blob/v1.0.0/examples/dns_configuration/main.tf#L39).
Therefore I think it fits nicely with the purpose of this module and will work well with other VPC Lattice software maintained by AWS.